### PR TITLE
fix: restore Tailwind layer order so anchor text-white applies

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,6 @@
+@import 'tailwindcss';
 @import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600&display=swap') layer(utilities);
 @import url('https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&display=swap') layer(utilities);
-@import 'tailwindcss';
 /*
   ---break---
 */


### PR DESCRIPTION
## Summary
- The Google Fonts `@import ... layer(utilities)` rules sat above `@import 'tailwindcss';` in `src/app/globals.css`. Because CSS layer order is locked in by first appearance of each layer name, that silently put `utilities` at the bottom of the cascade — below `base`.
- As a result, Tailwind preflight's `a { color: inherit }` (in `base`) beat every `.text-white` (in `utilities`) on `<a>` elements site-wide. Most visible: the header "Contact" pill rendered black text on a black background. Anywhere else an anchor relied on a Tailwind text-color utility was also affected.
- Fix: move `@import 'tailwindcss';` to the top of `globals.css` so Tailwind establishes the canonical `theme, base, components, utilities` order before the font imports add rules into the existing `utilities` layer.

## Test plan
- [x] `bun run build` succeeds
- [x] Local prod (`bun run start`) renders the header "Contact" button white-on-black
- [x] Layer-order probe in the running page (`@layer base/utilities` injected test) confirms `utilities` now wins
- [ ] After deploy, spot-check `/`, `/contact`, `/gridland`, `/thunderbolt` for any other anchor text-color regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)